### PR TITLE
Fix/ana/202504/corriendo mostrar roles usuarios

### DIFF
--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 
 const AdminDashboard = () => {
+  const [hoveredCard, setHoveredCard] = useState(null);
+
   return (
     <div style={dashboardStyle}>
       <div style={mainContainerStyle}>
@@ -16,39 +18,34 @@ const AdminDashboard = () => {
             
             <div style={dividerStyle}></div>
             
-            <p style={descriptionStyle}>
-              Gestiona toda la plataforma desde este panel
-            </p>
-          </div>
+            <p style={descriptionStyle}>Gestiona toda la plataforma desde este panel</p></div>
 
           <div style={cardsContainerStyle}>
-            <div style={cardStyle}>
-              <div style={cardIconStyle}>👥</div>
-              <h3 style={cardTitleStyle}>Usuarios</h3>
-              <p style={cardTextStyle}>Administra perfiles, roles y permisos</p>
-              <div style={cardHoverEffect}></div>
-            </div>
-            
-            <div style={cardStyle}>
-              <div style={cardIconStyle}>📊</div>
-              <h3 style={cardTitleStyle}>Reportes</h3>
-              <p style={cardTextStyle}>Genera análisis y estadísticas</p>
-              <div style={cardHoverEffect}></div>
-            </div>
-            
-            <div style={cardStyle}>
-              <div style={cardIconStyle}>🔄</div>
-              <h3 style={cardTitleStyle}>Suscripciones</h3>
-              <p style={cardTextStyle}>Gestiona membresías y renovaciones</p>
-              <div style={cardHoverEffect}></div>
-            </div>
-            
-            <div style={cardStyle}>
-              <div style={cardIconStyle}>📋</div>
-              <h3 style={cardTitleStyle}>Catálogos</h3>
-              <p style={cardTextStyle}>Administra Departamentos, Categorias, Condiciones, etc...</p>
-              <div style={cardHoverEffect}></div>
-            </div>
+            {[
+              { icon: "👥", title: "Usuarios", text: "Administra perfiles, roles y permisos" },
+              { icon: "📊", title: "Reportes", text: "Genera análisis y estadísticas" },
+              { icon: "🔄", title: "Suscripciones", text: "Gestiona membresías y renovaciones" },
+              { icon: "📋", title: "Catálogos", text: "Administra Departamentos, Categorías, etc." }
+            ].map((card, index) => (
+              <div 
+                key={index}
+                style={{
+                  ...cardStyle,
+                  transform: hoveredCard === index ? "translateY(-5px)" : "none",
+                  boxShadow: hoveredCard === index ? "0 10px 25px rgba(162, 105, 100, 0.1)" : "0 5px 15px rgba(0, 0, 0, 0.05)"
+                }}
+                onMouseEnter={() => setHoveredCard(index)}
+                onMouseLeave={() => setHoveredCard(null)}
+              >
+                <div style={cardIconStyle}>{card.icon}</div>
+                <h3 style={cardTitleStyle}>{card.title}</h3>
+                <p style={cardTextStyle}>{card.text}</p>
+                <div style={{
+                  ...cardHoverEffect,
+                  opacity: hoveredCard === index ? "1" : "0"
+                }}></div>
+              </div>
+            ))}
           </div>
         </div>
         
@@ -65,126 +62,129 @@ const AdminDashboard = () => {
   );
 };
 
-// Estilos 
+// Estilos
 const dashboardStyle = {
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
   minHeight: "calc(100vh - 80px)",
   background: "linear-gradient(135deg, #f5f7fa 0%, #c2d2c7 100%)",
-  padding: "40px",
+  padding: "20px",
+  overflow: "hidden"
 };
 
 const mainContainerStyle = {
   display: "flex",
-  maxWidth: "1200px",
+  maxWidth: "1000px",
   width: "100%",
-  borderRadius: "20px",
+  borderRadius: "16px",
   overflow: "hidden",
-  boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.15)",
+  boxShadow: "0 15px 30px -10px rgba(0, 0, 0, 0.1)",
   background: "#ffffff",
-  transition: "all 0.3s ease",
-  ":hover": {
-    boxShadow: "0 30px 60px -10px rgba(0, 0, 0, 0.2)"
-  }
+  height: "auto",
+  maxHeight: "90vh"
 };
 
 const contentContainerStyle = {
   flex: "1",
-  padding: "30px",
+  padding: "20px",
   display: "flex",
   flexDirection: "column",
-  justifyContent: "center"
+  justifyContent: "center",
+  overflowY: "auto"
 };
 
 const headerStyle = {
-  marginBottom: "50px",
+  marginBottom: "30px",
   textAlign: "left"
 };
 
 const titleStyle = {
   margin: "0",
-  lineHeight: "1.2",
-  fontWeight: "700"
+  lineHeight: "1.2"
 };
 
 const welcomeTextStyle = {
-  fontSize: "24px",
+  fontSize: "18px",
   color: "#A26964",
   fontWeight: "400",
   letterSpacing: "1px"
 };
 
 const brandTextStyle = {
-  fontSize: "42px",
+  fontSize: "32px",
   background: "linear-gradient(90deg, #A26964 0%, #C2D2C7 100%)",
   WebkitBackgroundClip: "text",
   WebkitTextFillColor: "transparent",
-  fontWeight: "800",
+  fontWeight: "700",
   display: "inline-block"
 };
 
 const subBrandTextStyle = {
-  fontSize: "52px",
+  fontSize: "40px",
   color: "#A26964",
-  fontWeight: "800",
+  fontWeight: "700",
   fontStyle: "italic"
 };
 
 const dividerStyle = {
-  height: "4px",
-  width: "100px",
+  height: "3px",
+  width: "80px",
   background: "linear-gradient(90deg, #A26964 0%, #C2D2C7 100%)",
-  margin: "20px 0",
+  margin: "15px 0",
   borderRadius: "2px"
 };
 
 const descriptionStyle = {
-  fontSize: "18px",
+  fontSize: "16px",
   color: "#6B7280",
-  maxWidth: "500px",
-  lineHeight: "1.6"
+  maxWidth: "400px",
+  lineHeight: "1.5",
+  marginBottom: "-30px",
+  marginTop: "0px" 
 };
 
 const cardsContainerStyle = {
   display: "grid",
-  gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-  gap: "20px",
+  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+  gap: "15px",
+  marginTop: "20px"
 };
 
 const cardStyle = {
   background: "#FFFFFF",
-  borderRadius: "12px",
-  padding: "25px",
+  borderRadius: "10px",
+  padding: "15px 20px",
   boxShadow: "0 5px 15px rgba(0, 0, 0, 0.05)",
   transition: "all 0.3s ease",
   position: "relative",
   overflow: "hidden",
   border: "1px solid rgba(162, 105, 100, 0.1)",
-  ":hover": {
-    transform: "translateY(-5px)",
-    boxShadow: "0 10px 25px rgba(162, 105, 100, 0.1)"
-  }
+  cursor: "pointer",
+  minHeight: "160px"
 };
 
 const cardIconStyle = {
-  fontSize: "32px",
-  marginBottom: "15px",
-  color: "#A26964"
+  fontSize: "28px",
+  marginBottom: "12px",
+  color: "#A26964",
+  transition: "all 0.3s ease"
 };
 
 const cardTitleStyle = {
-  margin: "0 0 10px 0",
+  margin: "0 0 8px 0",
   color: "#111827",
-  fontSize: "18px",
+  fontSize: "16px",
   fontWeight: "600"
 };
 
 const cardTextStyle = {
   margin: "0",
-  color: "#6B7280",
-  fontSize: "14px",
-  lineHeight: "1.5"
+  color: " #6B7280",
+  fontSize: "13px",
+  lineHeight: "1.2",
+  marginTop: "8px",
+  paddingBottom: "0"
 };
 
 const cardHoverEffect = {
@@ -194,21 +194,14 @@ const cardHoverEffect = {
   width: "100%",
   height: "100%",
   background: "linear-gradient(135deg, rgba(162, 105, 100, 0.1) 0%, rgba(194, 210, 199, 0.1) 100%)",
-  opacity: "0",
-  transition: "opacity 0.3s ease",
-  ":hover": {
-    opacity: "1"
-  }
+  transition: "opacity 0.3s ease"
 };
 
 const imageContainerStyle = {
   flex: "1",
   position: "relative",
-  minHeight: "500px",
-  display: "flex",
-  "@media (max-width: 900px)": {
-    display: "none"
-  }
+  minHeight: "400px",
+  display: "flex"
 };
 
 const imageStyle = {

--- a/src/components/AdminReports.jsx
+++ b/src/components/AdminReports.jsx
@@ -1,6 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 
 const AdminReports = () => {
+  const [hoveredCard, setHoveredCard] = useState(null);
+
+  const handleMouseEnter = (index) => {
+    setHoveredCard(index);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredCard(null);
+  };
+
   return (
     <div style={wrapperStyle}>
       <div style={containerStyle}>
@@ -9,62 +19,83 @@ const AdminReports = () => {
           <p style={subtitleStyle}>Visualización de datos y métricas clave</p>
         </div>
 
-        <div style={dashboardStyle}>
-          <div style={placeholderCardStyle}>
-            <div style={chartPlaceholderStyle}>
-              <div style={chartIconStyle}>📈</div>
-              <h3 style={chartTitleStyle}>Reportes en construcción</h3>
+        <div style={contentStyle}>
+          <div style={sectionStyle}>
+            <h2 style={sectionTitleStyle}>Reportes en construcción</h2>
+            <div style={metricsGridStyle}>
+              {[
+                {
+                  icon: "🛒",
+                  title: "Ventas",
+                  description: "Reportes de transacciones y conversiones",
+                  color: "#A26964"
+                },
+                {
+                  icon: "👥",
+                  title: "Usuarios",
+                  description: "Crecimiento y comportamiento de usuarios",
+                  color: "#A2B0CA"
+                },
+                {
+                  icon: "🔄",
+                  title: "Suscripciones",
+                  description: "Renovaciones y retención",
+                  color: "#C2D2C7"
+                },
+                {
+                  icon: "📦",
+                  title: "Inventario",
+                  description: "Movimiento y rotación de productos",
+                  color: "#E4C9B6"
+                }
+              ].map((metric, index) => (
+                <div 
+                  key={index}
+                  style={{
+                    ...metricCardStyle,
+                    backgroundColor: hoveredCard === index ? "#E4C9B6" : "#E1DAD3",
+                    transform: hoveredCard === index ? "translateY(-5px)" : "none",
+                    boxShadow: hoveredCard === index ? "0 10px 20px rgba(0,0,0,0.1)" : "none"
+                  }}
+                  onMouseEnter={() => handleMouseEnter(index)}
+                  onMouseLeave={handleMouseLeave}
+                >
+                  <div style={metricHeaderStyle}>
+                    <span style={{...metricIconStyle, color: metric.color}}>
+                      {metric.icon}
+                    </span>
+                    <h3 style={metricTitleStyle}>{metric.title}</h3>
+                  </div>
+                  <p style={metricDescriptionStyle}>{metric.description}</p>
+                </div>
+              ))}
             </div>
           </div>
 
-          <div style={metricsGridStyle}>
-            <div style={metricCardStyle}>
-              <div style={metricHeaderStyle}>
-                <span style={metricIconStyle}>🛒</span>
-                <h3 style={metricTitleStyle}>Ventas</h3>
-              </div>
-              <p style={metricDescriptionStyle}>
-                Reportes de transacciones y conversiones
-              </p>
+          <div style={sectionStyle}>
+            <h2 style={sectionTitleStyle}>Próximamente:</h2>
+            <div style={featuresGridStyle}>
+              {[
+                { icon: "📤", text: "Exportación a Excel/PDF" },
+                { icon: "🔍", text: "Filtros personalizados" },
+                { icon: "📊", text: "Dashboards interactivos" },
+                { icon: "🔔", text: "Alertas automáticas" }
+              ].map((feature, index) => (
+                <div 
+                  key={index}
+                  style={{
+                    ...featureItemStyle,
+                    backgroundColor: hoveredCard === index + 4 ? "#C2D2C7" : "#f1f3f5",
+                    color: hoveredCard === index + 4 ? "white" : "#495057",
+                    transform: hoveredCard === index + 4 ? "scale(1.05)" : "none"
+                  }}
+                  onMouseEnter={() => handleMouseEnter(index + 4)}
+                  onMouseLeave={handleMouseLeave}
+                >
+                  <span style={featureIconStyle}>{feature.icon}</span> {feature.text}
+                </div>
+              ))}
             </div>
-
-            <div style={metricCardStyle}>
-              <div style={metricHeaderStyle}>
-                <span style={metricIconStyle}>👥</span>
-                <h3 style={metricTitleStyle}>Usuarios</h3>
-              </div>
-              <p style={metricDescriptionStyle}>
-                Crecimiento y comportamiento de usuarios
-              </p>
-            </div>
-
-            <div style={metricCardStyle}>
-              <div style={metricHeaderStyle}>
-                <span style={metricIconStyle}>🔄</span>
-                <h3 style={metricTitleStyle}>Suscripciones</h3>
-              </div>
-              <p style={metricDescriptionStyle}>Renovaciones y retención</p>
-            </div>
-
-            <div style={metricCardStyle}>
-              <div style={metricHeaderStyle}>
-                <span style={metricIconStyle}>📦</span>
-                <h3 style={metricTitleStyle}>Inventario</h3>
-              </div>
-              <p style={metricDescriptionStyle}>
-                Movimiento y rotación de productos
-              </p>
-            </div>
-          </div>
-
-          <div style={upcomingFeaturesStyle}>
-            <h3 style={upcomingTitleStyle}>Próximamente:</h3>
-            <ul style={featuresListStyle}>
-              <li style={featureItemStyle}>Exportación a Excel/PDF</li>
-              <li style={featureItemStyle}>Filtros personalizados</li>
-              <li style={featureItemStyle}>Dashboards interactivos</li>
-              <li style={featureItemStyle}>Alertas automáticas</li>
-            </ul>
           </div>
         </div>
       </div>
@@ -74,141 +105,127 @@ const AdminReports = () => {
 
 // Estilos
 const wrapperStyle = {
-  minHeight: '100vh',
+  height: 'calc(100vh - 64px)',
   width: '100%',
   backgroundColor: '#f8f9fa',
   display: 'flex',
   justifyContent: 'center',
-  overflowY: 'auto',
+  overflow: 'hidden',
+  fontFamily: "'Poppins', sans-serif",
 };
 
 const containerStyle = {
-  width: '100%',
-  maxWidth: '1200px',
-  padding: '2rem',
-  fontFamily: "'Poppins', sans-serif",
+  width: '95%',
+  maxWidth: '900px',
+  padding: '1rem',
   boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
 };
 
 const headerStyle = {
-  marginBottom: '2rem',
-  paddingBottom: '1rem',
-  borderBottom: '2px solid #e9ecef',
+  marginBottom: '1rem',
+  paddingBottom: '0.5rem',
+  borderBottom: '1px solid #e9ecef',
 };
 
 const titleStyle = {
-  fontSize: '2rem',
+  fontSize: '1.6rem',
   fontWeight: '700',
-  color: '#343a40',
+  color: '#A26964',
   margin: '0',
+  fontFamily: "'Playfair Display', serif",
 };
 
 const subtitleStyle = {
-  fontSize: '1rem',
+  fontSize: '0.9rem',
   color: '#6c757d',
-  margin: '0.5rem 0 0 0',
+  margin: '0.25rem 0 0 0',
 };
 
-const dashboardStyle = {
+const contentStyle = {
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  overflow: 'hidden',
+};
+
+const sectionStyle = {
   backgroundColor: 'white',
-  borderRadius: '12px',
-  padding: '2rem',
-  boxShadow: '0 0.5rem 1rem rgba(0, 0, 0, 0.05)',
-  boxSizing: 'border-box',
-};
-
-const placeholderCardStyle = {
-  backgroundColor: '#f1f3f5',
   borderRadius: '10px',
-  padding: '3rem 2rem',
-  marginBottom: '2rem',
-  textAlign: 'center',
+  padding: '1.25rem',
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.08)',
 };
 
-const chartPlaceholderStyle = {
-  maxWidth: '600px',
-  margin: '0 auto',
-};
-
-const chartIconStyle = {
-  fontSize: '4rem',
-  marginBottom: '1rem',
-  color: '#495057',
-};
-
-const chartTitleStyle = {
-  fontSize: '1.5rem',
+const sectionTitleStyle = {
+  fontSize: '1.25rem',
   fontWeight: '600',
   color: '#212529',
   margin: '0 0 1rem 0',
+  fontFamily: "'Playfair Display', serif",
 };
 
 const metricsGridStyle = {
   display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
-  gap: '1.5rem',
-  marginBottom: '2rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+  gap: '1rem',
 };
 
 const metricCardStyle = {
-  backgroundColor: '#f8f9fa',
   borderRadius: '8px',
-  padding: '1.5rem',
-  borderLeft: '4px solid #adb5bd',
+  padding: '1rem',
+  borderLeft: '4px solid #A26964',
+  transition: 'all 0.3s ease',
+  cursor: 'pointer',
 };
 
 const metricHeaderStyle = {
   display: 'flex',
   alignItems: 'center',
-  marginBottom: '1rem',
+  marginBottom: '0.5rem',
 };
 
 const metricIconStyle = {
-  fontSize: '1.5rem',
+  fontSize: '1.4rem',
   marginRight: '0.75rem',
-  color: '#495057',
+  transition: 'all 0.3s ease',
 };
 
 const metricTitleStyle = {
-  fontSize: '1.1rem',
+  fontSize: '1.05rem',
   fontWeight: '600',
   color: '#212529',
   margin: '0',
 };
 
 const metricDescriptionStyle = {
-  fontSize: '0.9rem',
+  fontSize: '0.85rem',
   color: '#6c757d',
   margin: '0',
+  lineHeight: '1.4',
 };
 
-const upcomingFeaturesStyle = {
-  backgroundColor: '#e9ecef',
-  borderRadius: '8px',
-  padding: '1.5rem',
-};
-
-const upcomingTitleStyle = {
-  fontSize: '1.2rem',
-  fontWeight: '600',
-  color: '#212529',
-  margin: '0 0 1rem 0',
-};
-
-const featuresListStyle = {
+const featuresGridStyle = {
   display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-  gap: '0.75rem',
-  listStyle: 'none',
-  padding: '0',
-  margin: '0',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+  gap: '1rem',
 };
 
 const featureItemStyle = {
-  padding: '0.5rem 0.5rem 0.5rem 1.5rem',
-  position: 'relative',
-  fontSize: '0.95rem',
-  color: '#495057',
+  fontSize: '0.9rem',
+  padding: '0.75rem',
+  borderRadius: '6px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  transition: 'all 0.3s ease',
+};
+
+const featureIconStyle = {
+  marginRight: '0.5rem',
+  fontSize: '1.1rem',
+  transition: 'all 0.3s ease',
 };
 
 export default AdminReports;

--- a/src/components/AdminSubscriptions.jsx
+++ b/src/components/AdminSubscriptions.jsx
@@ -7,61 +7,104 @@ const AdminSubscriptions = () => {
         <h1 style={titleStyle}>Gestión de Suscripciones</h1>
         <p style={subtitleStyle}>Administra las membresías y suscripciones de los usuarios</p>
       </div>
-      
+
       <div style={placeholderStyle}>
         <div style={iconStyle}>📊</div>
         <h2 style={placeholderTitleStyle}>Sección en desarrollo</h2>
         <div style={featuresStyle}>
-          <div style={featureCardStyle}>
-            <div style={featureIconStyle}>🔄</div>
-            <h3 style={featureTitleStyle}>Renovaciones</h3>
-            <p style={featureTextStyle}>Gestiona las renovaciones automáticas</p>
-          </div>
-          <div style={featureCardStyle}>
-            <div style={featureIconStyle}>💰</div>
-            <h3 style={featureTitleStyle}>Pagos</h3>
-            <p style={featureTextStyle}>Visualiza historial de pagos</p>
-          </div>
-          <div style={featureCardStyle}>
-            <div style={featureIconStyle}>📈</div>
-            <h3 style={featureTitleStyle}>Estadísticas</h3>
-            <p style={featureTextStyle}>Analiza el crecimiento</p>
-          </div>
+          {features.map((feature, index) => (
+            <div key={index} style={featureCardStyle} className="feature-card">
+              <div className="icon-hover" style={featureIconStyle}>{feature.icon}</div>
+              <h3 style={featureTitleStyle}>{feature.title}</h3>
+              <p style={featureTextStyle}>{feature.description}</p>
+            </div>
+          ))}
         </div>
       </div>
+
+      <style>
+        {`
+          .feature-card {
+            transition: transform 0.3s ease, box-shadow 0.3s ease, background-color 0.3s ease;
+            cursor: pointer;
+          }
+
+          .feature-card:hover {
+            transform: translateY(-8px);
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+            background-color: #d6e5db; /* un babyGreen más clarito */
+          }
+
+          .icon-hover {
+            display: inline-block;
+            transition: transform 0.3s ease, filter 0.3s ease;
+          }
+
+          .feature-card:hover .icon-hover {
+            transform: scale(1.2) rotate(5deg);
+            filter: brightness(1.3) drop-shadow(0 0 5px rgba(255,255,255,0.6));
+          }
+        `}
+      </style>
     </div>
   );
 };
 
-// Estilos
+const features = [
+  {
+    icon: "🔄",
+    title: "Renovaciones",
+    description: "Gestiona las renovaciones automáticas",
+  },
+  {
+    icon: "💰",
+    title: "Pagos",
+    description: "Visualiza historial de pagos",
+  },
+  {
+    icon: "📈",
+    title: "Estadísticas",
+    description: "Analiza el crecimiento",
+  },
+];
+
+const colors = {
+  ivory: '#E1DAD3',
+  nude: '#E4C9B6',
+  coffee: '#A26964',
+  babyBlue: '#A2B0CA',
+  babyGreen: '#C2D2C7',
+};
+
 const containerStyle = {
   padding: '2rem',
   maxWidth: '1200px',
   margin: '0 auto',
-  fontFamily: "'Poppins', sans-serif",
+  fontFamily: "'Poppins', 'Playfair Display', sans-serif",
 };
 
 const headerStyle = {
   marginBottom: '2rem',
-  borderBottom: '2px solid #e2e8f0',
+  borderBottom: `2px solid ${colors.nude}`,
   paddingBottom: '1rem',
 };
 
 const titleStyle = {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#2d3748',
+  color: colors.coffee,
   margin: '0',
+  fontFamily: "'Playfair Display', serif",
 };
 
 const subtitleStyle = {
   fontSize: '1rem',
-  color: '#718096',
+  color: colors.nude,
   margin: '0.5rem 0 0 0',
 };
 
 const placeholderStyle = {
-  backgroundColor: '#f7fafc',
+  backgroundColor: colors.ivory,
   borderRadius: '12px',
   padding: '3rem 2rem',
   textAlign: 'center',
@@ -71,21 +114,15 @@ const placeholderStyle = {
 const iconStyle = {
   fontSize: '4rem',
   marginBottom: '1rem',
+  color: colors.babyBlue,
 };
 
 const placeholderTitleStyle = {
   fontSize: '1.5rem',
   fontWeight: '600',
-  color: '#2d3748',
+  color: colors.coffee,
   margin: '0 0 1rem 0',
-};
-
-const placeholderTextStyle = {
-  fontSize: '1rem',
-  color: '#4a5568',
-  maxWidth: '600px',
-  margin: '0 auto 2rem auto',
-  lineHeight: '1.6',
+  fontFamily: "'Playfair Display', serif",
 };
 
 const featuresStyle = {
@@ -96,32 +133,28 @@ const featuresStyle = {
 };
 
 const featureCardStyle = {
-  backgroundColor: 'white',
+  backgroundColor: colors.babyGreen,
   borderRadius: '8px',
   padding: '1.5rem',
-  boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
-  transition: 'transform 0.2s ease, box-shadow 0.2s ease',
-  ':hover': {
-    transform: 'translateY(-4px)',
-    boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)',
-  },
 };
 
 const featureIconStyle = {
   fontSize: '2rem',
   marginBottom: '1rem',
+  color: colors.coffee,
 };
 
 const featureTitleStyle = {
   fontSize: '1.1rem',
   fontWeight: '600',
-  color: '#2d3748',
+  color: colors.coffee,
   margin: '0 0 0.5rem 0',
+  fontFamily: "'Playfair Display', serif",
 };
 
 const featureTextStyle = {
   fontSize: '0.9rem',
-  color: '#718096',
+  color: '#2D2D2D',
   margin: '0',
 };
 

--- a/src/components/RegistrationRequests.jsx
+++ b/src/components/RegistrationRequests.jsx
@@ -11,7 +11,7 @@ const RegistrationRequests = () => {
 
         <div style={contentStyle}>
           <div style={iconContainerStyle}>
-            <span style={iconStyle}>📋</span>
+            <span style={iconStyle} className="hover-icon">📋</span>
           </div>
           <h2 style={placeholderTitleStyle}>Módulo en Desarrollo</h2>
           <p style={placeholderTextStyle}>Pronto podrás:</p>
@@ -22,35 +22,54 @@ const RegistrationRequests = () => {
           </ul>
 
           <div style={statsContainerStyle}>
-            <div style={statCardStyle}>
-              <span style={statNumberStyle}>0</span>
-              <span style={statLabelStyle}>Pendientes</span>
-            </div>
-            <div style={statCardStyle}>
-              <span style={statNumberStyle}>0</span>
-              <span style={statLabelStyle}>Aprobadas</span>
-            </div>
-            <div style={statCardStyle}>
-              <span style={statNumberStyle}>0</span>
-              <span style={statLabelStyle}>Rechazadas</span>
-            </div>
+            {['Pendientes', 'Aprobadas', 'Rechazadas'].map((label, i) => (
+              <div style={statCardStyle} className="stat-card" key={i}>
+                <span style={statNumberStyle}>0</span>
+                <span style={statLabelStyle}>{label}</span>
+              </div>
+            ))}
           </div>
         </div>
+
+        <style>
+          {`
+            .stat-card {
+              transition: transform 0.3s ease, box-shadow 0.3s ease;
+              cursor: pointer;
+            }
+
+            .stat-card:hover {
+              transform: translateY(-6px) scale(1.05);
+              box-shadow: 0 6px 15px rgba(0, 0, 0, 0.1);
+              background-color: #d9e6db;
+            }
+
+            .hover-icon {
+              display: inline-block;
+              transition: transform 0.3s ease;
+            }
+
+            .hover-icon:hover {
+              transform: rotate(8deg) scale(1.2);
+              filter: drop-shadow(0 0 6px rgba(162, 176, 202, 0.5));
+            }
+          `}
+        </style>
       </div>
     </div>
   );
 };
 
-// Estilos
 const wrapperStyle = {
   height: '100vh',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  backgroundColor: '#f0f2f5',
+  backgroundColor: '#E1DAD3',
   overflow: 'hidden',
   padding: '1rem',
-  boxSizing: 'border-box'
+  boxSizing: 'border-box',
+  fontFamily: "'Poppins', 'Playfair Display', sans-serif",
 };
 
 const containerStyle = {
@@ -61,52 +80,52 @@ const containerStyle = {
   maxWidth: '900px',
   width: '100%',
   boxSizing: 'border-box',
-  fontFamily: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif"
 };
 
 const headerStyle = {
   marginBottom: '2rem',
-  textAlign: 'center'
+  textAlign: 'center',
 };
 
 const titleStyle = {
   fontSize: '2.5rem',
   fontWeight: '700',
-  color: '#2c3e50',
-  margin: '0'
+  color: '#A26964',
+  margin: '0',
+  fontFamily: "'Playfair Display', serif",
 };
 
 const subtitleStyle = {
   fontSize: '1.1rem',
-  color: '#7f8c8d',
-  marginTop: '0.5rem'
+  color: '#926b60',
+  marginTop: '0.5rem',
 };
 
 const contentStyle = {
-  textAlign: 'center'
+  textAlign: 'center',
 };
 
 const iconContainerStyle = {
-  marginBottom: '1.5rem'
+  marginBottom: '1.5rem',
 };
 
 const iconStyle = {
   fontSize: '5rem',
-  color: '#3498db',
-  opacity: '0.9'
+  color: '#A2B0CA',
+  opacity: '0.9',
 };
 
 const placeholderTitleStyle = {
   fontSize: '1.8rem',
   fontWeight: '600',
-  color: '#34495e',
-  marginBottom: '1rem'
+  color: '#A26964',
+  marginBottom: '1rem',
 };
 
 const placeholderTextStyle = {
   fontSize: '1.1rem',
-  color: '#7f8c8d',
-  marginBottom: '1.5rem'
+  color: '#926b60',
+  marginBottom: '1.5rem',
 };
 
 const featureListStyle = {
@@ -115,14 +134,14 @@ const featureListStyle = {
   margin: '0 auto 2rem auto',
   maxWidth: '400px',
   textAlign: 'left',
-  color: '#2c3e50',
-  fontSize: '1rem'
+  color: '#5a5a5a',
+  fontSize: '1rem',
 };
 
 const featureItemStyle = {
   padding: '0.5rem 0',
   paddingLeft: '1.2rem',
-  position: 'relative'
+  position: 'relative',
 };
 
 const statsContainerStyle = {
@@ -130,30 +149,30 @@ const statsContainerStyle = {
   justifyContent: 'center',
   gap: '2rem',
   marginTop: '2rem',
-  flexWrap: 'wrap'
+  flexWrap: 'wrap',
 };
 
 const statCardStyle = {
-  backgroundColor: '#f8f9fa',
+  backgroundColor: '#C2D2C7',
   borderRadius: '8px',
   padding: '1rem 2rem',
   textAlign: 'center',
   boxShadow: '0 2px 6px rgba(0, 0, 0, 0.05)',
-  minWidth: '120px'
+  minWidth: '120px',
 };
 
 const statNumberStyle = {
   display: 'block',
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#2c3e50'
+  color: '#2D2D2D',
 };
 
 const statLabelStyle = {
   display: 'block',
   fontSize: '0.95rem',
-  color: '#7f8c8d',
-  marginTop: '0.3rem'
+  color: '#5a5a5a',
+  marginTop: '0.3rem',
 };
 
 export default RegistrationRequests;


### PR DESCRIPTION
Se corrigió la visualización de roles de usuarios para mostrar correctamente "Cliente", "Vendedor" y "Administrador" según los IDs (1005, 1006, 1007) que devuelve la API, implementando una función getRoleName() que traduce los valores y obtiene los roles desde /api/UserRoles. Además, se eliminó el campo de teléfono de la interfaz al no ser requerido, quitando su columna de la tabla y todas sus referencias en filtros y estilos. Los filtros por rol se actualizaron para usar los nuevos IDs y se ajustó el diseño de la tabla.